### PR TITLE
drop=FALSE; fix for #14

### DIFF
--- a/R/as_raster.R
+++ b/R/as_raster.R
@@ -49,7 +49,7 @@ setMethod("as_raster", signature(x = "Quadtree"),
       rast <- raster::raster(rast)
     }
     pts <- raster::rasterToPoints(rast, spatial = FALSE)
-    vals <- extract(x, pts[, 1:2])
+    vals <- extract(x, pts[, 1:2, drop = FALSE])
     rast[] <- vals
     return(rast)
   }


### PR DESCRIPTION
Hello!

Here is a suggested fix for the edge case of creating a 1x1 raster from a single cell quadtree.

With addition of `drop=FALSE` I now get:
```
> library(quadtree)
> qt <- quadtree(matrix(1), 1)
> as_raster(qt)
class      : RasterLayer 
dimensions : 1, 1, 1  (nrow, ncol, ncell)
resolution : 1, 1  (x, y)
extent     : 0, 1, 0, 1  (xmin, xmax, ymin, ymax)
crs        : NA 
source     : memory
names      : layer 
values     : 1, 1  (min, max)
```
rather than the error reported in #14 "Error in .local(x, y, ...) : 'y' must be a matrix or a data frame"