### PR TITLE
`quadtree()`: add minimal support for SpatRaster input #7

### DIFF
--- a/R/quadtree.R
+++ b/R/quadtree.R
@@ -160,6 +160,7 @@ setMethod("quadtree", signature(x = "ANY"),
            proj4string = NULL, template_quadtree = NULL) {
     # validate inputs - this may be over the top, but many of these values get passed to C++ functionality, and if they're the wrong type the errors that are thrown are totally unhelpful - by type-checking them right away, I can provide easy-to-interpret error messages rather than messages that provide zero help
     # also, this is a complex function with a ton of options, and this function is basically the entryway into the entire package, so I want the errors to clearly point the user to the problem
+    if (inherits(x, 'SpatRaster')) x <- raster::raster(x)
     if (!inherits(x, c("matrix", "RasterLayer"))) stop(paste0('"x" must be a "matrix" or "RasterLayer" - an object of class "', paste(class(x), collapse = '" "'), '" was provided instead'))
     if (is.null(template_quadtree) && split_method != "custom" && ((!is.numeric(split_threshold) && !is.null(split_threshold)) || length(split_threshold) != 1)) stop(paste0("'split_threshold' must be a 'numeric' vector of length 1"))
     if (!is.function(split_fun) && !is.null(split_fun)) stop(paste0("'split_fun' must be a function"))


### PR DESCRIPTION
Hi! Thanks for this great package.

I've switched essentially all my raster workflows to terra now and it would be convenient if quadtree() accepted the SpatRaster directly. So here is a 1-liner that adds  support for SpatRaster inputs RE: #7.

I am not sure whether you have plans to rewrite internals that currently use raster with terra (which would of course be a bigger job). I would be happy to contribute PR(s) that front if you want to try and go that direction. 

Otherwise something like this PR should cover most use cases; minimally allowing SpatRasters to be converted to RasterLayer, then to Quadtree.
